### PR TITLE
Use the pip package names for optional dependencies

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -202,7 +202,7 @@ on Linux!</em></p>
 <p>Once all the prerequisites are installed, the simplest way to get and
 start using PySAT is to install the latest stable release of the toolkit
 from <a href="https://pypi.org/project/python-sat/">PyPI</a>:<sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
-<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">pip install python-sat<span class="o">[</span>aiger,approxmc,pblib<span class="o">]</span>
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">pip install python-sat <span class="o">[</span>py-aiger pyapproxmc pypblib<span class="o">]</span>
 </span></span></code></pre></div><p>We encourage you to install the <em>optional</em> dependencies <em>pblib</em>, <em>aiger</em>, and
 <em>approxmc</em>, as shown in the previous command. However, if it cannot be done
 (e.g. if their installation fails), you can install PySAT with the


### PR DESCRIPTION
Took me a few minutes realizing the names was not the pip package names, but the project names. At first I suspected the packaged was incompatible with 3.11 so ruled that out before seeing the obvious.

Use the pip names in the command and space instead of comma for better paste-ability :)

The packages are referred to in the line below as well. I'm impartial to whether this should use the project or pip names :shrug: .